### PR TITLE
Change button type to 'button' to prevent page refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 <input class="title-input" type="text" name="" value="">
                 <label class="input-labels" for="">Body</label>
                 <textarea class="body-input"></textarea>
-                <input id="save-btn" type="submit" name="" value="Save" class="save-btn-disabled" disabled=true;>
+                <input id="save-btn" type="button" name="" value="Save" class="save-btn-disabled" disabled=true;>
                 <div class="search-form">
                     <button id="search-btn" type="button" name="button"></button>
                     <input id="search-input" type="text" name="" placeholder="Search ideas">

--- a/main.js
+++ b/main.js
@@ -13,3 +13,12 @@ form.addEventListener('input', function toggleDisableSave(event) {
         saveBtn.classList.remove('save-btn')
     }
 })
+
+
+form.addEventListener('click', addCard);
+
+function addCard() {
+  if (event.target.id === 'save-btn') {
+    console.log('adding a new card!');
+  }
+}


### PR DESCRIPTION
Hey team, I think I got this working how it should for now. I changed the input type from 'input' to 'button' so that the page will not automatically refresh on form submission. I also added a new function 'addCard()' to test this out. 

All it does right now is console log "adding a new card!", but it seems like those messages stack up in the console if the save button is clicked repeatedly, which I believe means the page is not reloading. 