### PR TITLE
Add functionality to reinstantiate cards as object instances

### DIFF
--- a/idea.js
+++ b/idea.js
@@ -7,15 +7,15 @@ class Idea {
     }
     starCard() {
         this.starred = !this.starred
+        console.log('test');
     }
 
     saveToStorage(allIdeas) {
 
         for (var i = 0; i < allIdeas.length; i++) {
-          var stringifiedArr = JSON.stringify(allIdeas);
+          // var stringifiedArr = JSON.stringify(allIdeas);
           localStorage.setItem('stringArr', JSON.stringify(allIdeas));
         }
-        console.log(stringifiedArr)
     }
 
     deleteFromStorage() {

--- a/idea.js
+++ b/idea.js
@@ -1,5 +1,5 @@
 class Idea {
-    constructor(title, body) {
+    constructor(title, body, id, starred) {
         this.title = title;
         this.body = body;
         this.id = Date.now();

--- a/index.html
+++ b/index.html
@@ -39,7 +39,5 @@
     </main>
 </body>
 <script src="idea.js"></script>
-
 <script src="main.js"></script>
-
 </html>

--- a/main.js
+++ b/main.js
@@ -9,18 +9,10 @@ form.addEventListener('input', toggleDisableSave);
 cardSection.addEventListener('click', deleteIdeaCard);
 
 
-
-
 function getFromStorage() {
     var getIdea = localStorage.getItem('stringArr');
     var parsedIdeas = JSON.parse(getIdea);
-      if (parsedIdeas !== null) {
-        for (var i = 0; i < parsedIdeas.length; i++) {
-          ideas.push(parsedIdeas[i]);
-        }
-          reinstantiateCards(parsedIdeas);
-          console.log(parsedIdeas);
-      }
+    objectsIntoInstances(parsedIdeas);
 }
 
 getFromStorage();
@@ -76,22 +68,15 @@ function starIdea(event) {
     if (event.target.classList.contains("star-image")) {
         event.target.classList.toggle('star-image-active');
     }
-
     var uniqueId = event.target.id;
     for (var i = 0; i < ideas.length; i++) {
         var arrayId = ideas[i].id * 2
         var objId = parseInt(uniqueId)
         console.log(arrayId, objId)
         if (arrayId === objId) {
-            // event.target.classList.toggle('star-image-active');
             ideas[i].starCard()
-            // ideas[i].starred = !ideas[i].starred;
-
             ideas[i].saveToStorage(ideas);
         }
-        // if (ideas[i].starred === false) {
-        //
-        // }
     }
 }
 
@@ -108,12 +93,22 @@ function deleteIdeaCard(event) {
             ideas[i].saveToStorage(ideas);
         }
     }
-
 }
 
+function objectsIntoInstances(localObject) {
+  if (localObject !== null) {
+    for (var i = 0; i < localObject.length; i++) {
+      var newInstance = new Idea(localObject[i].title, localObject[i].body, localObject[i].id, localObject[i].starred);
+      console.log(newInstance);
+      ideas.push(newInstance);
+    }
+    reinstantiateCards(ideas);
+    }
+  }
+
+
 function reinstantiateCards(newIdeas) {
-  if (newIdeas !== null) {
-    for (var i = 0; i < newIdeas.length; i++) {
+    for (var i = 0; i < ideas.length; i++) {
         cardSection.innerHTML += `<div id='${newIdeas[i].id}' class="card">
       <header>
           <button id='${newIdeas[i].id * 2}'  class="star-image" type="button" name="star"></button>
@@ -128,8 +123,5 @@ function reinstantiateCards(newIdeas) {
           <p id="comment">Comment</p>
       </footer>
   </div>`
-    }
-    var reinstateInstance = new Idea(newIdeas[i].title, newIdeas[i].body)
-  }
-
 }
+};

--- a/main.js
+++ b/main.js
@@ -11,17 +11,19 @@ cardSection.addEventListener('click', deleteIdeaCard);
 
 
 
-// function getFromStorage() {
-//     var getIdea = localStorage.getItem('stringArr');
-//     var parsedIdeas = JSON.parse(getIdea);
-//     console.log(parsedIdeas)
-//     if (ideas.length >= 1) {
-//       ideas.push(parsedIdeas);
-//       console.log(ideas);
-//     }
-// }
-//
-// getFromStorage();
+function getFromStorage() {
+    var getIdea = localStorage.getItem('stringArr');
+    var parsedIdeas = JSON.parse(getIdea);
+      if (parsedIdeas !== null) {
+        for (var i = 0; i < parsedIdeas.length; i++) {
+          ideas.push(parsedIdeas[i]);
+        }
+          reinstantiateCards(parsedIdeas);
+          console.log(parsedIdeas);
+      }
+}
+
+getFromStorage();
 
 function toggleDisableSave(event) {
     if (titleInput.value !== "" && bodyInput.value !== "") {
@@ -81,9 +83,15 @@ function starIdea(event) {
         var objId = parseInt(uniqueId)
         console.log(arrayId, objId)
         if (arrayId === objId) {
+            // event.target.classList.toggle('star-image-active');
             ideas[i].starCard()
+            // ideas[i].starred = !ideas[i].starred;
+
             ideas[i].saveToStorage(ideas);
         }
+        // if (ideas[i].starred === false) {
+        //
+        // }
     }
 }
 
@@ -100,5 +108,28 @@ function deleteIdeaCard(event) {
             ideas[i].saveToStorage(ideas);
         }
     }
+
+}
+
+function reinstantiateCards(newIdeas) {
+  if (newIdeas !== null) {
+    for (var i = 0; i < newIdeas.length; i++) {
+        cardSection.innerHTML += `<div id='${newIdeas[i].id}' class="card">
+      <header>
+          <button id='${newIdeas[i].id * 2}'  class="star-image" type="button" name="star"></button>
+          <button id="${newIdeas[i].id}" class="delete-btn" type="button" name="delete"></button>
+      </header>
+      <div class="card-body">
+          <h2>${newIdeas[i].title}</h2>
+          <p id="card-body-p">${newIdeas[i].body}</p>
+      </div>
+      <footer class="comment">
+          <button id="comment-btn" type="button" name="button"></button>
+          <p id="comment">Comment</p>
+      </footer>
+  </div>`
+    }
+    var reinstateInstance = new Idea(newIdeas[i].title, newIdeas[i].body)
+  }
 
 }


### PR DESCRIPTION
Our page now holds on to the cards on reload, but we are unable to star or delete the cards once they are reloaded. This commit begins to add some functionality that will allow us to pull the data from LS and re-instantiate it as object instances. 